### PR TITLE
Stepper: Visually larger elements

### DIFF
--- a/src/components/Migrate/Converter/ConverterSigning.tsx
+++ b/src/components/Migrate/Converter/ConverterSigning.tsx
@@ -1,28 +1,9 @@
 import React from 'react'
 import Stepper from '../../Stepper/Stepper'
-import { StepItems } from '../../Stepper/types'
-import { mockPromiseLatency, MOCK_HASH } from '../../../mock'
-
-const mockSteps: StepItems = [
-  {
-    title: 'Initiate ANT migration',
-    handleSign: async ({ setSuccess, setWorking, setError, setHash }) => {
-      try {
-        await mockPromiseLatency(1000)
-        setWorking()
-        setHash(MOCK_HASH)
-        await mockPromiseLatency(1000)
-        setSuccess()
-      } catch (err) {
-        console.error(err)
-        setError()
-      }
-    },
-  },
-]
+import { getMockSteps } from '../../../mock'
 
 function ConverterSigning(): JSX.Element {
-  return <Stepper steps={mockSteps} />
+  return <Stepper steps={getMockSteps(1)} />
 }
 
 export default ConverterSigning

--- a/src/components/Stepper/Step/Divider.tsx
+++ b/src/components/Stepper/Step/Divider.tsx
@@ -1,4 +1,6 @@
 import React from 'react'
+// @ts-ignore
+import { GU } from '@aragon/ui'
 
 type DividerProps = {
   color: string
@@ -6,7 +8,13 @@ type DividerProps = {
 
 function Divider({ color, ...props }: DividerProps): JSX.Element {
   return (
-    <svg width="75.75" height="9.53" viewBox="0 0 75.75 9.53" {...props}>
+    <svg
+      css={`
+        width: ${13 * GU}px;
+      `}
+      viewBox="0 0 75.75 9.53"
+      {...props}
+    >
       <path d="M3.75,4.76,0,9.53V0Z" fill={color} opacity="0.3" />
       <path d="M11.75,4.76,8,9.53V0Z" fill={color} opacity="0.4" />
       <path d="M19.75,4.76,16,9.53V0Z" fill={color} opacity="0.5" />

--- a/src/components/Stepper/Step/StatusVisual.tsx
+++ b/src/components/Stepper/Step/StatusVisual.tsx
@@ -67,10 +67,11 @@ function StatusVisual({
   return (
     <div
       css={`
+        font-size: ${14 * GU}px;
         display: flex;
         position: relative;
-        width: ${13.5 * GU}px;
-        height: ${13.5 * GU}px;
+        width: 1em;
+        height: 1em;
       `}
       {...props}
     >
@@ -103,11 +104,11 @@ function StatusVisual({
               onStart={enableAnimation}
               immediate={animationDisabled}
               from={{
-                transform: 'scale3d(1.3, 1.3, 1)',
+                scale: 1.3,
               }}
               enter={{
                 opacity: 1,
-                transform: 'scale3d(1, 1, 1)',
+                scale: 1,
               }}
               leave={{
                 position: 'absolute' as const,
@@ -126,11 +127,19 @@ function StatusVisual({
                       padding: ${0.25 * GU}px;
                       background-color: ${theme.surface};
                       color: ${color};
-                      border: 1px solid currentColor;
+                      border: 2px solid currentColor;
                       bottom: 0;
                       right: 0;
                     `}
-                    style={animProps}
+                    style={{
+                      ...animProps,
+                      // Prevent rasterization artifacts by removing transform once animation has completed
+                      // Current spring version has misaligned typings on 'interpolate'
+                      // @ts-ignore
+                      transform: animProps.scale.interpolate((scale: number) =>
+                        scale !== 1 ? `scale3d(${scale}, ${scale}, 1)` : 'none'
+                      ),
+                    }}
                   >
                     {currentStatusIcon}
                   </AnimatedDiv>
@@ -189,8 +198,8 @@ function StepIllustration({ number, status }: StepIllustrationProps) {
   return (
     <div
       css={`
-        width: ${8.5 * GU}px;
-        height: ${8.5 * GU}px;
+        width: 0.65em;
+        height: 0.65em;
       `}
     >
       {renderIllustration ? (

--- a/src/components/Stepper/Step/StatusVisual.tsx
+++ b/src/components/Stepper/Step/StatusVisual.tsx
@@ -70,6 +70,7 @@ function StatusVisual({
         font-size: ${14 * GU}px;
         display: flex;
         position: relative;
+        // Using 'em' units allows us to uniformly scale the graphic via 'font-size' without having to manage individual dimensions.
         width: 1em;
         height: 1em;
       `}

--- a/src/components/Stepper/Step/Step.tsx
+++ b/src/components/Stepper/Step/Step.tsx
@@ -5,7 +5,6 @@ import { TransactionBadge, textStyle, useTheme, RADIUS, GU } from '@aragon/ui'
 import Divider from './Divider'
 import { networkEnvironment } from '../../../environment'
 import StatusVisual from './StatusVisual'
-
 import { springs } from '../../../style/springs'
 import { useDisableAnimation } from '../../../hooks/useDisableAnimation'
 import { StepStatus } from '../types'
@@ -73,7 +72,7 @@ function Step({
           flex-direction: column;
           align-items: center;
 
-          width: ${31 * GU}px;
+          width: ${35 * GU}px;
         `}
         {...props}
       >
@@ -87,11 +86,10 @@ function Step({
         />
         <h2
           css={`
-            ${textStyle('title4')}
-
+            font-size: 22px;
             line-height: 1.2;
             text-align: center;
-            margin-bottom: ${1 * GU}px;
+            margin-bottom: ${1.2 * GU}px;
           `}
         >
           {status === 'error' ? 'Transaction failed' : title}
@@ -102,6 +100,8 @@ function Step({
             width: 100%;
             position: relative;
             text-align: center;
+
+            ${textStyle('body1')}
             color: ${theme.contentSecondary};
             line-height: 1.2;
           `}
@@ -150,7 +150,7 @@ function Step({
 
         <div
           css={`
-            margin-top: ${1.5 * GU}px;
+            margin-top: ${2.5 * GU}px;
             position: relative;
             width: 100%;
           `}

--- a/src/components/Stepper/types.ts
+++ b/src/components/Stepper/types.ts
@@ -8,15 +8,17 @@ export type StepStatus =
 
 export type StepDescriptions = Record<StepStatus, string>
 
+export type StepHandleSignProps = {
+  setPrompting: () => void
+  setWorking: () => void
+  setError: () => void
+  setSuccess: () => void
+  setHash: (hash: string) => void
+}
+
 export interface StepItem {
   title: string
-  handleSign: (renderProps: {
-    setPrompting: () => void
-    setWorking: () => void
-    setError: () => void
-    setSuccess: () => void
-    setHash: (hash: string) => void
-  }) => void
+  handleSign: (renderProps: StepHandleSignProps) => void
   descriptions?: StepDescriptions
 }
 

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -1,6 +1,37 @@
+import {
+  StepHandleSignProps,
+  StepItem,
+  StepItems,
+} from './components/Stepper/types'
+
 export const MOCK_HASH =
   '0xaa1eff68a2d66769c0bf51f28ed4d9c7723805d2c253ecfc898d31977e8c92b7'
 
 export async function mockPromiseLatency(ms: number): Promise<boolean> {
   return new Promise((resolve) => setTimeout(() => resolve(true), ms))
+}
+
+const mockStepItem: StepItem = {
+  title: 'Initiate ANT migration',
+  handleSign: async ({
+    setSuccess,
+    setWorking,
+    setError,
+    setHash,
+  }: StepHandleSignProps): Promise<void> => {
+    try {
+      await mockPromiseLatency(1000)
+      setWorking()
+      setHash(MOCK_HASH)
+      await mockPromiseLatency(1000)
+      setSuccess()
+    } catch (err) {
+      console.error(err)
+      setError()
+    }
+  },
+}
+
+export function getMockSteps(count = 1): StepItems {
+  return Array(count).fill(mockStepItem)
 }


### PR DESCRIPTION
As we know ahead of time that we'll only have <= 2 steps, we can tweak them to be larger (per the designs)

![image](https://user-images.githubusercontent.com/11708259/95735643-fe7cc580-0c7c-11eb-8561-21e7803b77af.png)
