### PR TITLE
Style: Add shadow presets

### DIFF
--- a/src/components/Migrate/Converter/ConverterForm.tsx
+++ b/src/components/Migrate/Converter/ConverterForm.tsx
@@ -13,6 +13,7 @@ import {
 import { fontWeight } from '../../../style/font'
 import { TokenConversionType } from '../types'
 import { useMigrateState } from '../MigrateStateProvider'
+import { shadowDepth } from '../../../style/shadow'
 
 const BLOG_POST_URL = ''
 const MOCK_AMOUNT = '78,000'
@@ -51,7 +52,7 @@ function ConverterForm(): JSX.Element {
         max-width: ${130 * GU}px;
         padding: ${6 * GU}px;
         background-color: ${theme.surface};
-        box-shadow: rgba(0, 0, 0, 0.15) 0px 2px 5px;
+        box-shadow: ${shadowDepth.far};
         border-radius: ${1.5 * GU}px;
         display: grid;
         grid-gap: ${4 * GU}px;

--- a/src/style/shadow.ts
+++ b/src/style/shadow.ts
@@ -7,9 +7,9 @@ export const shadowDepth = {
     shadowTint,
     0.03
   )}`,
-  medium: `0px 2px 4px ${rgba(shadowTint, 0.01)}, 0px 10px 20px ${rgba(
+  medium: `0px 2px 4px ${rgba(shadowTint, 0.03)}, 0px 10px 20px ${rgba(
     shadowTint,
-    0.075
+    0.06
   )}`,
   far: `0px 5px 10px ${rgba(shadowTint, 0.01)}, 0px 15px 50px ${rgba(
     shadowTint,

--- a/src/style/shadow.ts
+++ b/src/style/shadow.ts
@@ -1,0 +1,18 @@
+import { rgba } from 'polished'
+
+const shadowTint = '#1a2130'
+
+export const shadowDepth = {
+  close: `0px 1px 2px ${rgba(shadowTint, 0.1)}, 0px 4px 10px ${rgba(
+    shadowTint,
+    0.03
+  )}`,
+  medium: `0px 2px 4px r${rgba(shadowTint, 0.01)}, 0px 10px 20px ${rgba(
+    shadowTint,
+    0.075
+  )}`,
+  far: `0px 5px 10px ${rgba(shadowTint, 0.01)}, 0px 15px 50px ${rgba(
+    shadowTint,
+    0.075
+  )}`,
+}

--- a/src/style/shadow.ts
+++ b/src/style/shadow.ts
@@ -7,7 +7,7 @@ export const shadowDepth = {
     shadowTint,
     0.03
   )}`,
-  medium: `0px 2px 4px r${rgba(shadowTint, 0.01)}, 0px 10px 20px ${rgba(
+  medium: `0px 2px 4px ${rgba(shadowTint, 0.01)}, 0px 10px 20px ${rgba(
     shadowTint,
     0.075
   )}`,


### PR DESCRIPTION
@delfipolito I've added three levels of shadow to align with the branding, you'll likely need to use the `far` option for the ANT page cards. The FAQ items would probably use `close`. Feel free to tweak these if needed! though we should try to stick to the same few values to keep things looking consistent.

![image](https://user-images.githubusercontent.com/11708259/95795461-46820380-0ce2-11eb-83d6-6ddec232d1c0.png)
