### PR TITLE
Account module: Open from outer context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,18 +7,21 @@ import Routes from './Routes'
 import { breakpoints } from './style/breakpoints'
 import { WalletProvider } from './providers/Wallet'
 import { AccountBalancesProvider } from './providers/AccountBalances'
+import { AccountModuleProvider } from './components/Account/AccountModuleProvider'
 
 function App(): JSX.Element {
   return (
     <WalletProvider>
       <AccountBalancesProvider>
-        <LayoutProvider breakpoints={breakpoints}>
-          <Router>
-            <MainView>
-              <Routes />
-            </MainView>
-          </Router>
-        </LayoutProvider>
+        <AccountModuleProvider>
+          <LayoutProvider breakpoints={breakpoints}>
+            <Router>
+              <MainView>
+                <Routes />
+              </MainView>
+            </Router>
+          </LayoutProvider>
+        </AccountModuleProvider>
       </AccountBalancesProvider>
     </WalletProvider>
   )

--- a/src/components/Account/AccountModal.tsx
+++ b/src/components/Account/AccountModal.tsx
@@ -1,20 +1,14 @@
 import React, { ReactNode, useEffect, useRef, useState } from 'react'
 import { Spring, Transition, animated } from 'react-spring/renderprops'
 import {
-  Modal,
   textStyle,
   springs,
-  ButtonIcon,
-  IconCross,
-  useTheme,
   GU,
   // @ts-ignore
 } from '@aragon/ui'
 import { ScreenId, WalletError, WalletConnector } from './types'
 import { fontWeight } from '../../style/font'
-import { shadowDepth } from '../../style/shadow'
-import { rgba } from 'polished'
-import { radius } from '../../style/radius'
+import BrandModal from '../BrandModal/BrandModal'
 
 interface ScreenData {
   account: string | null
@@ -45,7 +39,6 @@ function AccountModal({
   screenId,
   direction,
 }: AccountModalProps): JSX.Element {
-  const theme = useTheme()
   const [animate, setAnimate] = useState(false)
   const [height, setHeight] = useState(30 * GU)
   const [measuredHeight, setMeasuredHeight] = useState(true)
@@ -76,133 +69,90 @@ function AccountModal({
   }, [visible])
 
   return (
-    <Modal
-      visible={visible}
-      onClose={onClose}
-      closeButton={false}
-      padding={0}
-      css={`
-        > div > div > div {
-          border-radius: ${radius.high} !important;
-          box-shadow: ${shadowDepth.high};
-        }
-
-        background-color: ${rgba('#787c85', 0.25)};
-      `}
-    >
-      <section
-        css={`
-          display: flex;
-          flex-direction: column;
-          overflow: hidden;
-          padding: ${4 * GU}px;
-        `}
-      >
-        <div
+    <BrandModal visible={visible} onClose={onClose}>
+      <>
+        <h1
           css={`
-            position: relative;
+            display: flex;
+            flex-grow: 0;
+            flex-shrink: 0;
+            align-items: center;
+            margin-bottom: ${3 * GU}px;
+
+            ${textStyle('body2')};
+            font-weight: ${fontWeight.medium};
+            line-height: 1;
           `}
         >
-          <ButtonIcon
-            label=""
-            css={`
-              position: absolute;
-              top: -${1 * GU}px;
-              right: -${1 * GU}px;
-              z-index: 2;
-            `}
-            onClick={onClose}
-          >
-            <IconCross
+          {heading}
+        </h1>
+        <Spring
+          config={springs.smooth}
+          from={{ height: 32 * GU }}
+          to={{ height }}
+          immediate={!animate}
+          native
+        >
+          {({ height }) => (
+            <AnimatedDiv
+              ref={popoverFocusElement}
+              tabIndex={0}
+              style={{ height: measuredHeight ? height : 'auto' }}
               css={`
-                color: ${theme.surfaceContent};
+                position: relative;
+                flex-grow: 1;
+                width: 100%;
+                outline: 0;
               `}
-            />
-          </ButtonIcon>
-
-          <h1
-            css={`
-              display: flex;
-              flex-grow: 0;
-              flex-shrink: 0;
-              align-items: center;
-              margin-bottom: ${3 * GU}px;
-
-              ${textStyle('body2')};
-              font-weight: ${fontWeight.medium};
-              line-height: 1;
-            `}
-          >
-            {heading}
-          </h1>
-          <Spring
-            config={springs.smooth}
-            from={{ height: 32 * GU }}
-            to={{ height }}
-            immediate={!animate}
-            native
-          >
-            {({ height }) => (
-              <AnimatedDiv
-                ref={popoverFocusElement}
-                tabIndex={0}
-                style={{ height: measuredHeight ? height : 'auto' }}
-                css={`
-                  position: relative;
-                  flex-grow: 1;
-                  width: 100%;
-                  outline: 0;
-                `}
+            >
+              <Transition
+                native
+                config={springs.smooth}
+                items={screenData}
+                keys={({ account, activating, activationError, screenId }) =>
+                  (activationError ? activationError.name : '') +
+                  account +
+                  activating +
+                  screenId
+                }
+                from={{
+                  opacity: 0,
+                  transform: `translate3d(${3 * GU * direction}px, 0, 0)`,
+                }}
+                enter={{ opacity: 1, transform: `translate3d(0, 0, 0)` }}
+                leave={{
+                  opacity: 0,
+                  transform: `translate3d(${3 * GU * -direction}px, 0, 0)`,
+                }}
+                immediate={!animate}
+                onStart={() => {
+                  setMeasuredHeight(true)
+                }}
               >
-                <Transition
-                  native
-                  config={springs.smooth}
-                  items={screenData}
-                  keys={({ account, activating, activationError, screenId }) =>
-                    (activationError ? activationError.name : '') +
-                    account +
-                    activating +
-                    screenId
-                  }
-                  from={{
-                    opacity: 0,
-                    transform: `translate3d(${3 * GU * direction}px, 0, 0)`,
-                  }}
-                  enter={{ opacity: 1, transform: `translate3d(0, 0, 0)` }}
-                  leave={{
-                    opacity: 0,
-                    transform: `translate3d(${3 * GU * -direction}px, 0, 0)`,
-                  }}
-                  immediate={!animate}
-                  onStart={() => {
-                    setMeasuredHeight(true)
-                  }}
-                >
-                  {(screenData) => ({ opacity, transform }) => (
-                    <AnimatedDiv
-                      ref={(elt) => {
-                        if (elt) {
-                          setHeight(elt.clientHeight)
-                        }
-                      }}
-                      style={{ opacity, transform }}
-                      css={`
-                        position: ${measuredHeight ? 'absolute' : 'static'};
-                        top: 0;
-                        left: 0;
-                        right: 0;
-                      `}
-                    >
-                      {children(screenData)}
-                    </AnimatedDiv>
-                  )}
-                </Transition>
-              </AnimatedDiv>
-            )}
-          </Spring>
-        </div>
-      </section>
-    </Modal>
+                {(screenData) => ({ opacity, transform }) => (
+                  <AnimatedDiv
+                    ref={(elt) => {
+                      if (elt) {
+                        setHeight(elt.clientHeight)
+                      }
+                    }}
+                    style={{ opacity, transform }}
+                    css={`
+                      position: ${measuredHeight ? 'absolute' : 'static'};
+                      top: 0;
+                      left: 0;
+                      right: 0;
+                    `}
+                  >
+                    {children(screenData)}
+                  </AnimatedDiv>
+                )}
+              </Transition>
+            </AnimatedDiv>
+          )}
+        </Spring>
+      </>
+    </BrandModal>
   )
 }
 

--- a/src/components/Account/AccountModal.tsx
+++ b/src/components/Account/AccountModal.tsx
@@ -1,10 +1,8 @@
-import React, { useState, useEffect, useRef, ReactNode } from 'react'
-// @ts-ignore
-import { GU, Popover, springs, textStyle, useTheme } from '@aragon/ui'
+import React, { ReactNode, useEffect, useRef, useState } from 'react'
 import { Spring, Transition, animated } from 'react-spring/renderprops'
+// @ts-ignore
+import { Modal, textStyle, useTheme, springs, GU } from '@aragon/ui'
 import { ScreenId, WalletError, WalletConnector } from './types'
-
-const AnimatedDiv = animated.div
 
 interface ScreenData {
   account: string | null
@@ -14,27 +12,27 @@ interface ScreenData {
   screenId: ScreenId
 }
 
-type AccountPopoverProps = {
-  children: (screenData: ScreenData) => ReactNode
-  direction: -1 | 1
-  heading: ReactNode
-  onClose: () => void
-  opener: HTMLElement
-  screenData: ScreenData
-  screenId: string
+type AccountModalProps = {
   visible: boolean
+  children: (screenData: ScreenData) => ReactNode
+  onClose: () => void
+  screenData: ScreenData
+  heading: ReactNode
+  screenId: string
+  direction: -1 | 1
 }
 
-function AccountPopover({
-  children,
-  direction,
-  heading,
-  onClose,
-  opener,
-  screenData,
-  screenId,
+const AnimatedDiv = animated.div
+
+function AccountModal({
   visible,
-}: AccountPopoverProps): JSX.Element {
+  children,
+  onClose,
+  screenData,
+  heading,
+  screenId,
+  direction,
+}: AccountModalProps): JSX.Element {
   const theme = useTheme()
 
   const [animate, setAnimate] = useState(false)
@@ -67,16 +65,7 @@ function AccountPopover({
   }, [visible])
 
   return (
-    <Popover
-      closeOnOpenerFocus
-      onClose={onClose}
-      opener={opener}
-      placement="bottom-end"
-      visible={visible}
-      css={`
-        width: ${51 * GU}px;
-      `}
-    >
+    <Modal visible={visible} onClose={onClose}>
       <section
         css={`
           display: flex;
@@ -166,8 +155,8 @@ function AccountPopover({
           )}
         </Spring>
       </section>
-    </Popover>
+    </Modal>
   )
 }
 
-export default AccountPopover
+export default AccountModal

--- a/src/components/Account/AccountModal.tsx
+++ b/src/components/Account/AccountModal.tsx
@@ -1,8 +1,11 @@
 import React, { ReactNode, useEffect, useRef, useState } from 'react'
 import { Spring, Transition, animated } from 'react-spring/renderprops'
 // @ts-ignore
-import { Modal, textStyle, useTheme, springs, GU } from '@aragon/ui'
+import { Modal, textStyle, springs, GU } from '@aragon/ui'
 import { ScreenId, WalletError, WalletConnector } from './types'
+import { fontWeight } from '../../style/font'
+import { shadowDepth } from '../../style/shadow'
+import { rgba } from 'polished'
 
 interface ScreenData {
   account: string | null
@@ -33,8 +36,6 @@ function AccountModal({
   screenId,
   direction,
 }: AccountModalProps): JSX.Element {
-  const theme = useTheme()
-
   const [animate, setAnimate] = useState(false)
   const [height, setHeight] = useState(30 * GU)
   const [measuredHeight, setMeasuredHeight] = useState(true)
@@ -65,12 +66,25 @@ function AccountModal({
   }, [visible])
 
   return (
-    <Modal visible={visible} onClose={onClose}>
+    <Modal
+      visible={visible}
+      onClose={onClose}
+      padding={0}
+      css={`
+        > div > div > div {
+          border-radius: 12px !important;
+          box-shadow: ${shadowDepth.high};
+        }
+
+        background-color: ${rgba('#787c85', 0.25)};
+      `}
+    >
       <section
         css={`
           display: flex;
           flex-direction: column;
           overflow: hidden;
+          padding: ${4 * GU}px;
         `}
       >
         <h1
@@ -79,11 +93,11 @@ function AccountModal({
             flex-grow: 0;
             flex-shrink: 0;
             align-items: center;
-            height: ${4 * GU}px;
-            padding-left: ${2 * GU}px;
-            border-bottom: 1px solid ${theme.border};
-            color: ${theme.surfaceContentSecondary};
-            ${textStyle('label2')};
+            margin-bottom: ${3 * GU}px;
+
+            ${textStyle('body2')};
+            font-weight: ${fontWeight.medium};
+            line-height: 1;
           `}
         >
           {heading}
@@ -104,7 +118,6 @@ function AccountModal({
                 position: relative;
                 flex-grow: 1;
                 width: 100%;
-                overflow: hidden;
                 outline: 0;
               `}
             >

--- a/src/components/Account/AccountModal.tsx
+++ b/src/components/Account/AccountModal.tsx
@@ -14,6 +14,7 @@ import { ScreenId, WalletError, WalletConnector } from './types'
 import { fontWeight } from '../../style/font'
 import { shadowDepth } from '../../style/shadow'
 import { rgba } from 'polished'
+import { radius } from '../../style/radius'
 
 interface ScreenData {
   account: string | null
@@ -82,7 +83,7 @@ function AccountModal({
       padding={0}
       css={`
         > div > div > div {
-          border-radius: 12px !important;
+          border-radius: ${radius.high} !important;
           box-shadow: ${shadowDepth.high};
         }
 

--- a/src/components/Account/AccountModal.tsx
+++ b/src/components/Account/AccountModal.tsx
@@ -1,7 +1,15 @@
 import React, { ReactNode, useEffect, useRef, useState } from 'react'
 import { Spring, Transition, animated } from 'react-spring/renderprops'
-// @ts-ignore
-import { Modal, textStyle, springs, GU } from '@aragon/ui'
+import {
+  Modal,
+  textStyle,
+  springs,
+  ButtonIcon,
+  IconCross,
+  useTheme,
+  GU,
+  // @ts-ignore
+} from '@aragon/ui'
 import { ScreenId, WalletError, WalletConnector } from './types'
 import { fontWeight } from '../../style/font'
 import { shadowDepth } from '../../style/shadow'
@@ -36,6 +44,7 @@ function AccountModal({
   screenId,
   direction,
 }: AccountModalProps): JSX.Element {
+  const theme = useTheme()
   const [animate, setAnimate] = useState(false)
   const [height, setHeight] = useState(30 * GU)
   const [measuredHeight, setMeasuredHeight] = useState(true)
@@ -69,6 +78,7 @@ function AccountModal({
     <Modal
       visible={visible}
       onClose={onClose}
+      closeButton={false}
       padding={0}
       css={`
         > div > div > div {
@@ -87,86 +97,109 @@ function AccountModal({
           padding: ${4 * GU}px;
         `}
       >
-        <h1
+        <div
           css={`
-            display: flex;
-            flex-grow: 0;
-            flex-shrink: 0;
-            align-items: center;
-            margin-bottom: ${3 * GU}px;
-
-            ${textStyle('body2')};
-            font-weight: ${fontWeight.medium};
-            line-height: 1;
+            position: relative;
           `}
         >
-          {heading}
-        </h1>
-        <Spring
-          config={springs.smooth}
-          from={{ height: 32 * GU }}
-          to={{ height }}
-          immediate={!animate}
-          native
-        >
-          {({ height }) => (
-            <AnimatedDiv
-              ref={popoverFocusElement}
-              tabIndex={0}
-              style={{ height: measuredHeight ? height : 'auto' }}
+          <ButtonIcon
+            label=""
+            css={`
+              position: absolute;
+              top: -${1 * GU}px;
+              right: -${1 * GU}px;
+              z-index: 2;
+            `}
+            onClick={onClose}
+          >
+            <IconCross
               css={`
-                position: relative;
-                flex-grow: 1;
-                width: 100%;
-                outline: 0;
+                color: ${theme.surfaceContent};
               `}
-            >
-              <Transition
-                native
-                config={springs.smooth}
-                items={screenData}
-                keys={({ account, activating, activationError, screenId }) =>
-                  (activationError ? activationError.name : '') +
-                  account +
-                  activating +
-                  screenId
-                }
-                from={{
-                  opacity: 0,
-                  transform: `translate3d(${3 * GU * direction}px, 0, 0)`,
-                }}
-                enter={{ opacity: 1, transform: `translate3d(0, 0, 0)` }}
-                leave={{
-                  opacity: 0,
-                  transform: `translate3d(${3 * GU * -direction}px, 0, 0)`,
-                }}
-                immediate={!animate}
-                onStart={() => {
-                  setMeasuredHeight(true)
-                }}
+            />
+          </ButtonIcon>
+
+          <h1
+            css={`
+              display: flex;
+              flex-grow: 0;
+              flex-shrink: 0;
+              align-items: center;
+              margin-bottom: ${3 * GU}px;
+
+              ${textStyle('body2')};
+              font-weight: ${fontWeight.medium};
+              line-height: 1;
+            `}
+          >
+            {heading}
+          </h1>
+          <Spring
+            config={springs.smooth}
+            from={{ height: 32 * GU }}
+            to={{ height }}
+            immediate={!animate}
+            native
+          >
+            {({ height }) => (
+              <AnimatedDiv
+                ref={popoverFocusElement}
+                tabIndex={0}
+                style={{ height: measuredHeight ? height : 'auto' }}
+                css={`
+                  position: relative;
+                  flex-grow: 1;
+                  width: 100%;
+                  outline: 0;
+                `}
               >
-                {(screenData) => ({ opacity, transform }) => (
-                  <AnimatedDiv
-                    ref={(elt) => {
-                      if (elt) {
-                        setHeight(elt.clientHeight)
-                      }
-                    }}
-                    style={{ opacity, transform }}
-                    css={`
-                      position: ${measuredHeight ? 'absolute' : 'static'};
-                      top: 0;
-                      left: 0;
-                      right: 0;
-                    `}
-                  >
-                    {children(screenData)}
-                  </AnimatedDiv>
-                )}
-              </Transition>
-            </AnimatedDiv>
-          )}
-        </Spring>
+                <Transition
+                  native
+                  config={springs.smooth}
+                  items={screenData}
+                  keys={({ account, activating, activationError, screenId }) =>
+                    (activationError ? activationError.name : '') +
+                    account +
+                    activating +
+                    screenId
+                  }
+                  from={{
+                    opacity: 0,
+                    transform: `translate3d(${3 * GU * direction}px, 0, 0)`,
+                  }}
+                  enter={{ opacity: 1, transform: `translate3d(0, 0, 0)` }}
+                  leave={{
+                    opacity: 0,
+                    transform: `translate3d(${3 * GU * -direction}px, 0, 0)`,
+                  }}
+                  immediate={!animate}
+                  onStart={() => {
+                    setMeasuredHeight(true)
+                  }}
+                >
+                  {(screenData) => ({ opacity, transform }) => (
+                    <AnimatedDiv
+                      ref={(elt) => {
+                        if (elt) {
+                          setHeight(elt.clientHeight)
+                        }
+                      }}
+                      style={{ opacity, transform }}
+                      css={`
+                        position: ${measuredHeight ? 'absolute' : 'static'};
+                        top: 0;
+                        left: 0;
+                        right: 0;
+                      `}
+                    >
+                      {children(screenData)}
+                    </AnimatedDiv>
+                  )}
+                </Transition>
+              </AnimatedDiv>
+            )}
+          </Spring>
+        </div>
       </section>
     </Modal>
   )

--- a/src/components/Account/AccountModule.tsx
+++ b/src/components/Account/AccountModule.tsx
@@ -37,6 +37,8 @@ function AccountModule(): JSX.Element {
   )
 
   useEffect(() => {
+    let autocloseTimer: number
+
     if (status === 'error') {
       setActivatingDelayed(null)
     }
@@ -44,7 +46,13 @@ function AccountModule(): JSX.Element {
     if (status === 'connecting') {
       setActivatingDelayed(connector)
     }
-  }, [connector, status])
+
+    if (status === 'connected') {
+      autocloseTimer = setTimeout(hideAccount, 500)
+    }
+
+    return () => clearTimeout(autocloseTimer)
+  }, [connector, status, hideAccount])
 
   const handleResetConnection = useCallback(() => {
     wallet.reset()

--- a/src/components/Account/AccountModule.tsx
+++ b/src/components/Account/AccountModule.tsx
@@ -48,7 +48,7 @@ function AccountModule(): JSX.Element {
     }
 
     if (status === 'connected') {
-      autocloseTimer = setTimeout(hideAccount, 500)
+      autocloseTimer = setTimeout(hideAccount, 1000)
     }
 
     return () => clearTimeout(autocloseTimer)

--- a/src/components/Account/AccountModule.tsx
+++ b/src/components/Account/AccountModule.tsx
@@ -10,6 +10,7 @@ import ScreenError from './ScreenError'
 import ScreenProviders from './ScreenProviders'
 import { ScreenConfig, WalletConnector } from './types'
 import AccountModal from './AccountModal'
+import { useAccountModule } from './AccountModuleProvider'
 
 const SCREENS: ScreenConfig[] = [
   { id: 'providers', title: 'Use account from' },
@@ -21,7 +22,7 @@ const SCREENS: ScreenConfig[] = [
 function AccountModule(): JSX.Element {
   const wallet = useWallet()
   const { account, connector, error, status } = wallet
-  const [opened, setOpened] = useState(false)
+  const { accountVisible, showAccount, hideAccount } = useAccountModule()
   const [
     activatingDelayed,
     setActivatingDelayed,
@@ -30,7 +31,10 @@ function AccountModule(): JSX.Element {
   const { below } = useViewport()
   const compactMode = below('medium')
 
-  const toggle = useCallback(() => setOpened((opened) => !opened), [])
+  const toggle = useCallback(
+    () => (accountVisible ? hideAccount() : showAccount()),
+    [accountVisible, showAccount, hideAccount]
+  )
 
   useEffect(() => {
     if (status === 'error') {
@@ -70,14 +74,6 @@ function AccountModule(): JSX.Element {
   const screen = SCREENS[screenIndex]
   const screenId = screen.id
 
-  const handlePopoverClose = useCallback(() => {
-    // Reject closing the popover when connecting or on error
-    if (screenId === 'connecting' || screenId === 'error') {
-      return false
-    }
-    setOpened(false)
-  }, [screenId])
-
   return (
     <div
       ref={buttonRef}
@@ -104,7 +100,7 @@ function AccountModule(): JSX.Element {
       <AccountModal
         direction={direction}
         heading={screen.title}
-        onClose={handlePopoverClose}
+        onClose={hideAccount}
         screenId={screenId}
         screenData={{
           account,
@@ -113,7 +109,7 @@ function AccountModule(): JSX.Element {
           status,
           screenId,
         }}
-        visible={opened}
+        visible={accountVisible}
       >
         {({ activating, activationError, screenId }) => {
           if (screenId === 'connecting') {

--- a/src/components/Account/AccountModule.tsx
+++ b/src/components/Account/AccountModule.tsx
@@ -1,15 +1,15 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useWallet } from '../../providers/Wallet'
 // @ts-ignore
-import { GU, IconConnect, useViewport } from '@aragon/ui'
+import { IconConnect, useViewport, GU } from '@aragon/ui'
 import AccountButton from './AccountButton'
-import AccountPopover from './AccountPopover'
 import BrandButton from '../BrandButton/BrandButton'
 import ScreenConnected from './ScreenConnected'
 import ScreenConnecting from './ScreenConnecting'
 import ScreenError from './ScreenError'
 import ScreenProviders from './ScreenProviders'
 import { ScreenConfig, WalletConnector } from './types'
+import AccountModal from './AccountModal'
 
 const SCREENS: ScreenConfig[] = [
   { id: 'providers', title: 'Use account from' },
@@ -100,11 +100,11 @@ function AccountModule(): JSX.Element {
           display={compactMode ? 'icon' : 'all'}
         />
       )}
-      <AccountPopover
+
+      <AccountModal
         direction={direction}
         heading={screen.title}
         onClose={handlePopoverClose}
-        opener={buttonRef.current}
         screenId={screenId}
         screenData={{
           account,
@@ -137,7 +137,7 @@ function AccountModule(): JSX.Element {
           }
           return <ScreenProviders onActivate={handleActivate} />
         }}
-      </AccountPopover>
+      </AccountModal>
     </div>
   )
 }

--- a/src/components/Account/AccountModuleProvider.tsx
+++ b/src/components/Account/AccountModuleProvider.tsx
@@ -19,7 +19,7 @@ function AccountModuleProvider({
 }: {
   children: ReactNode
 }): JSX.Element {
-  const [accountVisible, setAccountVisible] = useState(false)
+  const [accountVisible, setAccountVisible] = useState(true)
 
   const showAccount = useCallback(() => setAccountVisible(true), [])
   const hideAccount = useCallback(() => setAccountVisible(false), [])

--- a/src/components/Account/AccountModuleProvider.tsx
+++ b/src/components/Account/AccountModuleProvider.tsx
@@ -1,0 +1,48 @@
+import React, {
+  ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react'
+
+type AccountContext = {
+  accountVisible: boolean
+  showAccount: () => void
+  hideAccount: () => void
+}
+
+const AccountModuleContext = React.createContext<AccountContext | null>(null)
+
+function AccountModuleProvider({
+  children,
+}: {
+  children: ReactNode
+}): JSX.Element {
+  const [accountVisible, setAccountVisible] = useState(false)
+
+  const showAccount = useCallback(() => setAccountVisible(true), [])
+  const hideAccount = useCallback(() => setAccountVisible(false), [])
+
+  const contextValue = useMemo(
+    (): AccountContext => ({
+      accountVisible,
+      showAccount,
+      hideAccount,
+    }),
+
+    [accountVisible, showAccount, hideAccount]
+  )
+
+  return (
+    <AccountModuleContext.Provider value={contextValue}>
+      {children}
+    </AccountModuleContext.Provider>
+  )
+}
+
+function useAccountModule(): AccountContext {
+  return useContext(AccountModuleContext) as AccountContext
+}
+
+export { useAccountModule, AccountModuleProvider }

--- a/src/components/Account/AccountModuleProvider.tsx
+++ b/src/components/Account/AccountModuleProvider.tsx
@@ -19,7 +19,7 @@ function AccountModuleProvider({
 }: {
   children: ReactNode
 }): JSX.Element {
-  const [accountVisible, setAccountVisible] = useState(true)
+  const [accountVisible, setAccountVisible] = useState(false)
 
   const showAccount = useCallback(() => setAccountVisible(true), [])
   const hideAccount = useCallback(() => setAccountVisible(false), [])

--- a/src/components/Account/ScreenConnected.tsx
+++ b/src/components/Account/ScreenConnected.tsx
@@ -28,11 +28,7 @@ function ScreenConnected(): JSX.Element {
   const providerInfo = getProviderFromUseWalletId(connector)
 
   return (
-    <div
-      css={`
-        padding: ${2 * GU}px;
-      `}
-    >
+    <>
       <div
         css={`
           display: flex;
@@ -127,7 +123,7 @@ function ScreenConnected(): JSX.Element {
       >
         Disconnect wallet
       </BrandButton>
-    </div>
+    </>
   )
 }
 

--- a/src/components/Account/ScreenConnected.tsx
+++ b/src/components/Account/ScreenConnected.tsx
@@ -49,11 +49,14 @@ function ScreenConnected(): JSX.Element {
             css={`
               width: ${2.5 * GU}px;
               height: ${2.5 * GU}px;
-              margin-right: ${0.5 * GU}px;
-              transform: translateY(-2px);
+              margin-right: ${1 * GU}px;
             `}
           />
-          <span>
+          <span
+            css={`
+              line-height: 1;
+            `}
+          >
             {providerInfo.id === 'unknown' ? 'Wallet' : providerInfo.name}
           </span>
         </div>
@@ -66,7 +69,9 @@ function ScreenConnected(): JSX.Element {
           `}
         >
           <ButtonBase
-            onClick={() => copy(account ? account : '')}
+            onClick={() =>
+              copy(account ? account : '', 'Address copied to clipboard')
+            }
             focusRingRadius={RADIUS}
             css={`
               display: flex;
@@ -99,7 +104,8 @@ function ScreenConnected(): JSX.Element {
         css={`
           display: flex;
           align-items: center;
-          margin-top: ${1 * GU}px;
+          margin-top: ${1.5 * GU}px;
+          margin-bottom: ${2 * GU}px;
           color: ${theme.positive};
           ${textStyle('label2')};
         `}
@@ -114,13 +120,7 @@ function ScreenConnected(): JSX.Element {
         </span>
       </div>
 
-      <BrandButton
-        onClick={() => reset()}
-        wide
-        css={`
-          margin-top: ${1 * GU}px;
-        `}
-      >
+      <BrandButton onClick={() => reset()} wide>
         Disconnect wallet
       </BrandButton>
     </>

--- a/src/components/Account/ScreenConnecting.tsx
+++ b/src/components/Account/ScreenConnecting.tsx
@@ -9,6 +9,7 @@ import {
 
 import loadingRing from './assets/loading-ring.svg'
 import { WalletConnector } from './types'
+import { fontWeight } from '../../style/font'
 
 const spin = keyframes`
   from {
@@ -40,7 +41,6 @@ function ScreenConnecting({
         flex-direction: column;
         align-items: center;
         justify-content: center;
-        padding: ${2 * GU}px;
         height: 100%;
       `}
     >
@@ -93,7 +93,8 @@ function ScreenConnecting({
           css={`
             padding-top: ${2 * GU}px;
             ${textStyle('body1')};
-            font-weight: 600;
+            font-weight: ${fontWeight.medium};
+            margin-bottom: ${0.5 * GU}px;
           `}
         >
           Connecting to {provider.name}
@@ -102,6 +103,8 @@ function ScreenConnecting({
           css={`
             width: ${36 * GU}px;
             color: ${theme.surfaceContentSecondary};
+            line-height: 1.4;
+            margin-bottom: ${1 * GU}px;
           `}
         >
           Log into {getProviderString('your Ethereum wallet', provider.id)}. You

--- a/src/components/Account/ScreenError.tsx
+++ b/src/components/Account/ScreenError.tsx
@@ -6,6 +6,7 @@ import { getNetworkName } from '../../lib/web3-utils'
 import { networkEnvironment } from '../../environment'
 import connectionError from './assets/connection-error.png'
 import { WalletError } from './types'
+import { fontWeight } from '../../style/font'
 
 type ScreenErrorProps = {
   error: WalletError
@@ -65,7 +66,8 @@ function ScreenError({ error, onBack }: ScreenErrorProps): JSX.Element {
           css={`
             padding-top: ${2 * GU}px;
             ${textStyle('body1')};
-            font-weight: 600;
+            font-weight: ${fontWeight.medium};
+            margin-bottom: ${0.5 * GU}px;
           `}
         >
           {title}

--- a/src/components/Account/ScreenError.tsx
+++ b/src/components/Account/ScreenError.tsx
@@ -39,7 +39,7 @@ function ScreenError({ error, onBack }: ScreenErrorProps): JSX.Element {
         flex-direction: column;
         align-items: center;
         justify-content: center;
-        padding: ${2 * GU}px;
+        margin-top: -${2 * GU}px;
         height: 100%;
       `}
     >
@@ -74,6 +74,8 @@ function ScreenError({ error, onBack }: ScreenErrorProps): JSX.Element {
           css={`
             width: ${36 * GU}px;
             color: ${theme.surfaceContentSecondary};
+            line-height: 1.4;
+            margin-bottom: ${1 * GU}px;
           `}
         >
           {secondary}

--- a/src/components/Account/ScreenProviders.tsx
+++ b/src/components/Account/ScreenProviders.tsx
@@ -1,12 +1,13 @@
 import React, { useCallback } from 'react'
 // @ts-ignore
-import { ButtonBase, GU, Link, RADIUS, useTheme, textStyle } from '@aragon/ui'
+import { ButtonBase, GU, Link, useTheme, textStyle } from '@aragon/ui'
 import {
   getProviderFromUseWalletId,
   getUseWalletProviders,
 } from './ethereum-providers'
 import { ProviderConfig, WalletConnector } from './types'
 import { shadowDepth } from '../../style/shadow'
+import { radius } from '../../style/radius'
 
 const PROVIDERS_INFO: [
   WalletConnector,
@@ -95,7 +96,7 @@ function ProviderButton({ id, provider, onActivate }: ProviderButtonProps) {
         padding: ${3 * GU}px;
         background-color: ${theme.surface};
         box-shadow: ${shadowDepth.low};
-        border-radius: ${RADIUS}px;
+        border-radius: ${radius.medium};
 
         &:active {
           top: 1px;

--- a/src/components/Account/ScreenProviders.tsx
+++ b/src/components/Account/ScreenProviders.tsx
@@ -6,6 +6,7 @@ import {
   getUseWalletProviders,
 } from './ethereum-providers'
 import { ProviderConfig, WalletConnector } from './types'
+import { shadowDepth } from '../../style/shadow'
 
 const PROVIDERS_INFO: [
   WalletConnector,
@@ -27,7 +28,6 @@ function ScreenProviders({ onActivate }: ScreenProvidersProps): JSX.Element {
         flex-direction: column;
         justify-content: center;
         width: 100%;
-        padding: ${2 * GU}px ${2 * GU}px 0;
       `}
     >
       <div
@@ -51,14 +51,14 @@ function ScreenProviders({ onActivate }: ScreenProvidersProps): JSX.Element {
         css={`
           display: flex;
           justify-content: center;
-          margin-top: ${2 * GU}px;
-          padding-bottom: ${2 * GU}px;
+          margin-top: ${3.5 * GU}px;
         `}
       >
         <Link
           href="https://ethereum.org/wallets/"
           css={`
             text-decoration: none;
+            line-height: 1;
           `}
         >
           Don’t have an Ethereum account?
@@ -92,10 +92,11 @@ function ProviderButton({ id, provider, onActivate }: ProviderButtonProps) {
         align-items: center;
         justify-content: center;
         width: 100%;
-        height: ${12 * GU}px;
-        background: ${theme.surface};
-        box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.15);
+        padding: ${3 * GU}px;
+        background-color: ${theme.surface};
+        box-shadow: ${shadowDepth.low};
         border-radius: ${RADIUS}px;
+
         &:active {
           top: 1px;
           box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
@@ -105,8 +106,9 @@ function ProviderButton({ id, provider, onActivate }: ProviderButtonProps) {
       <img src={provider.image} alt="" height={5.25 * GU} />
       <div
         css={`
-          margin-top: ${1 * GU}px;
+          margin-top: ${1.25 * GU}px;
           ${textStyle('body1')};
+          line-height: 1;
         `}
       >
         {provider.name}

--- a/src/components/Account/ScreenProviders.tsx
+++ b/src/components/Account/ScreenProviders.tsx
@@ -99,15 +99,15 @@ function ProviderButton({ id, provider, onActivate }: ProviderButtonProps) {
 
         &:active {
           top: 1px;
-          box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
+          box-shadow: ${shadowDepth.extraLow};
         }
       `}
     >
       <img src={provider.image} alt="" height={5.25 * GU} />
       <div
         css={`
-          margin-top: ${1.25 * GU}px;
-          ${textStyle('body1')};
+          margin-top: ${1.5 * GU}px;
+          ${textStyle('body2')};
           line-height: 1;
         `}
       >

--- a/src/components/BrandButton/BrandButton.tsx
+++ b/src/components/BrandButton/BrandButton.tsx
@@ -3,6 +3,7 @@ import React, { AllHTMLAttributes, ReactNode } from 'react'
 import { Button, useTheme } from '@aragon/ui'
 import { shadowDepth } from '../../style/shadow'
 import { fontWeight } from '../../style/font'
+import { radius } from '../../style/radius'
 
 type NativeButtonProps = AllHTMLAttributes<HTMLButtonElement>
 
@@ -43,7 +44,7 @@ function BrandButton({
       wide={wide}
       css={`
         border: 0;
-        border-radius: 6px;
+        border-radius: ${radius.medium};
 
         font-weight: ${fontWeight.medium};
         ${!disabled ? `box-shadow: ${shadowDepth.low};` : ''}

--- a/src/components/BrandModal/BrandModal.tsx
+++ b/src/components/BrandModal/BrandModal.tsx
@@ -1,0 +1,73 @@
+import React, { ReactNode } from 'react'
+// @ts-ignore
+import { Modal, IconCross, ButtonIcon, useTheme, GU } from '@aragon/ui'
+import { shadowDepth } from '../../style/shadow'
+import { radius } from '../../style/radius'
+import { rgba } from 'polished'
+
+type BrandModalProps = {
+  visible: boolean
+  onClose: () => void
+  children: ReactNode
+}
+
+function BrandModal({
+  children,
+  visible,
+  onClose,
+}: BrandModalProps): JSX.Element {
+  const theme = useTheme()
+
+  const scrimColor = rgba(`#${theme.disabledContent.hexColor}`, 0.3)
+
+  return (
+    <Modal
+      visible={visible}
+      onClose={onClose}
+      closeButton={false}
+      padding={0}
+      css={`
+        > div > div > div {
+          border-radius: ${radius.high} !important;
+          box-shadow: ${shadowDepth.high};
+        }
+
+        background-color: ${scrimColor};
+      `}
+    >
+      <div
+        css={`
+          position: relative;
+          overflow: hidden;
+          padding: ${4 * GU}px;
+        `}
+      >
+        <div
+          css={`
+            position: relative;
+          `}
+        >
+          <ButtonIcon
+            label=""
+            css={`
+              position: absolute;
+              top: -${1 * GU}px;
+              right: -${1 * GU}px;
+              z-index: 2;
+            `}
+            onClick={onClose}
+          >
+            <IconCross
+              css={`
+                color: ${theme.surfaceContent};
+              `}
+            />
+          </ButtonIcon>
+          {children}
+        </div>
+      </div>
+    </Modal>
+  )
+}
+
+export default BrandModal

--- a/src/components/Migrate/Converter/ConverterForm.tsx
+++ b/src/components/Migrate/Converter/ConverterForm.tsx
@@ -14,6 +14,7 @@ import { useMigrateState } from '../MigrateStateProvider'
 import { shadowDepth } from '../../../style/shadow'
 import { useAccountBalances } from '../../../providers/AccountBalances'
 import ConverterFormControls from './ConverterFormControls'
+import { radius } from '../../../style/radius'
 
 const AMOUNT_DIGITS = 6
 const TOKEN_SYMBOL: Record<TokenConversionType, string> = {
@@ -63,7 +64,7 @@ function ConverterForm(): JSX.Element {
         padding: ${6 * GU}px;
         background-color: ${theme.surface};
         box-shadow: ${shadowDepth.high};
-        border-radius: ${1.5 * GU}px;
+        border-radius: ${radius.high};
         display: grid;
         grid-gap: ${4 * GU}px;
         ${compactMode ? stackedLayout : multiColumnLayout}
@@ -101,7 +102,7 @@ function ConverterForm(): JSX.Element {
           justify-content: center;
           grid-area: rate;
           border: 1px dashed ${theme.border};
-          border-radius: ${1 * GU}px;
+          border-radius: ${radius.high};
         `}
       >
         Conversion Rate

--- a/src/components/Migrate/Converter/ConverterFormControls.tsx
+++ b/src/components/Migrate/Converter/ConverterFormControls.tsx
@@ -72,7 +72,6 @@ function ConverterFormControls({
       }
 
       if (validationStatus === 'notConnected') {
-        // TODO: Add call to account module
         showAccount()
       }
     },

--- a/src/components/Migrate/Converter/ConverterFormControls.tsx
+++ b/src/components/Migrate/Converter/ConverterFormControls.tsx
@@ -9,7 +9,6 @@ import {
   Info,
   IconExternal,
   GU,
-  noop,
   // @ts-ignore
 } from '@aragon/ui'
 import BrandButton from '../../BrandButton/BrandButton'
@@ -19,6 +18,7 @@ import ConverterButton from './ConverterButton'
 import useInputValidation from './useInputValidation'
 import { networkEnvironment } from '../../../environment'
 import { shadowDepth } from '../../../style/shadow'
+import { useAccountModule } from '../../Account/AccountModuleProvider'
 
 const FLOAT_REGEX = /^\d*[.]?\d*$/
 
@@ -36,6 +36,7 @@ function ConverterFormControls({
   const [amount, setAmount] = useState('')
   const theme = useTheme()
   const { continueToSigning, updateConvertAmount } = useMigrateState()
+  const { showAccount } = useAccountModule()
   const { layoutName } = useLayout()
   const {
     formattedAmount,
@@ -72,10 +73,10 @@ function ConverterFormControls({
 
       if (validationStatus === 'notConnected') {
         // TODO: Add call to account module
-        noop()
+        showAccount()
       }
     },
-    [validationStatus, continueToSigning]
+    [validationStatus, continueToSigning, showAccount]
   )
 
   // Pass updated amount to context state for use in the signing stepper

--- a/src/style/radius.ts
+++ b/src/style/radius.ts
@@ -1,0 +1,8 @@
+//@ts-ignore
+import { RADIUS, GU } from '@aragon/ui'
+
+export const radius = {
+  low: `${RADIUS}px`,
+  medium: `${0.75 * GU}px`,
+  high: `${1.5 * GU}px`,
+}

--- a/src/style/shadow.ts
+++ b/src/style/shadow.ts
@@ -3,6 +3,10 @@ import { rgba } from 'polished'
 const shadowTint = '#1a2130'
 
 export const shadowDepth = {
+  extraLow: `0px 1px 1px ${rgba(shadowTint, 0.1)}, 0px 1px 10px ${rgba(
+    shadowTint,
+    0.025
+  )}`,
   low: `0px 1px 2px ${rgba(shadowTint, 0.1)}, 0px 2px 20px ${rgba(
     shadowTint,
     0.05

--- a/src/style/shadow.ts
+++ b/src/style/shadow.ts
@@ -11,8 +11,8 @@ export const shadowDepth = {
     shadowTint,
     0.06
   )}`,
-  high: `0px 5px 10px ${rgba(shadowTint, 0.01)}, 0px 15px 50px ${rgba(
+  high: `0px 5px 10px ${rgba(shadowTint, 0.02)}, 0px 15px 50px ${rgba(
     shadowTint,
-    0.075
+    0.08
   )}`,
 }


### PR DESCRIPTION
The account popover now uses a modal pattern which can be called externally from outside of the button element. I also updated the style to match the branding.

![image](https://user-images.githubusercontent.com/11708259/96061894-3dcd3100-0e8c-11eb-84e8-4470ec46dada.png)
