### PR TITLE
Balances: Add dynamic balances

### DIFF
--- a/src/components/GetStarted/BalanceCard.tsx
+++ b/src/components/GetStarted/BalanceCard.tsx
@@ -106,7 +106,7 @@ function BalanceCard({
               font-variant-numeric: tabular-nums;
             `}
           >
-            {balance}
+            {balance && balance}
             <span
               css={`
                 color: ${theme.contentSecondary};

--- a/src/components/GetStarted/BalanceCard.tsx
+++ b/src/components/GetStarted/BalanceCard.tsx
@@ -64,7 +64,7 @@ function BalanceCard({
           display: flex;
           align-items: center;
           padding-bottom: ${5 * GU}px;
-          margin-bottom: ${5 * GU}px;
+          margin-bottom: ${4.5 * GU}px;
           border-bottom: 1px solid ${theme.border};
         `}
       >
@@ -96,6 +96,7 @@ function BalanceCard({
       <div
         css={`
           font-size: 18px;
+          line-height: 1;
         `}
       >
         {accountConnected ? (

--- a/src/components/GetStarted/BalanceCard.tsx
+++ b/src/components/GetStarted/BalanceCard.tsx
@@ -15,6 +15,7 @@ type BalanceCardProps = {
   tokenVersion: TokenType
   price: string | null
   balance: string | null
+  accountConnected?: boolean
 }
 
 type TokenPresentation = Record<
@@ -43,6 +44,7 @@ function BalanceCard({
   tokenVersion = 'v1',
   price,
   balance,
+  accountConnected,
 }: BalanceCardProps): JSX.Element {
   const theme = useTheme()
 
@@ -91,33 +93,48 @@ function BalanceCard({
           <PriceWithSkeleton price={price} />
         </div>
       </div>
-      <ul>
-        <li
-          css={`
-            display: flex;
-            justify-content: space-between;
-            font-size: 18px;
-          `}
-        >
-          <h4>Wallet balance</h4>
-          <span
-            css={`
-              letter-spacing: -0.02em;
-              font-variant-numeric: tabular-nums;
-            `}
-          >
-            {balance && balance}
-            <span
+      <div
+        css={`
+          font-size: 18px;
+        `}
+      >
+        {accountConnected ? (
+          <ul>
+            <li
               css={`
-                color: ${theme.contentSecondary};
-                margin-left: ${0.75 * GU}px;
+                display: flex;
+                justify-content: space-between;
               `}
             >
-              ANT
-            </span>
-          </span>
-        </li>
-      </ul>
+              <h4>Wallet balance</h4>
+              <span
+                css={`
+                  letter-spacing: -0.02em;
+                  font-variant-numeric: tabular-nums;
+                `}
+              >
+                {balance && balance}
+                <span
+                  css={`
+                    color: ${theme.contentSecondary};
+                    margin-left: ${0.75 * GU}px;
+                  `}
+                >
+                  ANT
+                </span>
+              </span>
+            </li>
+          </ul>
+        ) : (
+          <p
+            css={`
+              color: ${theme.contentSecondary};
+            `}
+          >
+            Enable account to see your balance
+          </p>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/components/GetStarted/Balances.tsx
+++ b/src/components/GetStarted/Balances.tsx
@@ -47,11 +47,13 @@ function Balances(): JSX.Element {
           tokenVersion="v1"
           price={antTokenPriceUsd}
           balance={formattedAntV1Balance}
+          accountConnected={formattedAntV1Balance}
         />
         <BalanceCard
           tokenVersion="v2"
           price={antTokenPriceUsd}
           balance={formattedAntV2Balance}
+          accountConnected={formattedAntV2Balance}
         />
       </div>
     </LayoutLimiter>

--- a/src/components/GetStarted/Balances.tsx
+++ b/src/components/GetStarted/Balances.tsx
@@ -1,14 +1,36 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 // @ts-ignore
 import { useLayout, GU } from '@aragon/ui'
+// @ts-ignore
+import TokenAmount from 'token-amount'
 import LayoutLimiter from '../Layout/LayoutLimiter'
 import BalanceCard from './BalanceCard'
 import { useAccountBalances } from '../../providers/AccountBalances'
 
+const FORMATTED_DIGITS = 2
+
 function Balances(): JSX.Element {
   const { layoutName } = useLayout()
-  const { antTokenPriceUsd } = useAccountBalances()
+  const { antTokenPriceUsd, antV1, antV2 } = useAccountBalances()
   const stackedCards = layoutName === 'small' || layoutName === 'medium'
+
+  const formattedAntV1Balance = useMemo(
+    () =>
+      antV1.balance &&
+      new TokenAmount(antV1.balance, antV1.decimals).format({
+        digits: FORMATTED_DIGITS,
+      }),
+    [antV1.balance, antV1.decimals]
+  )
+
+  const formattedAntV2Balance = useMemo(
+    () =>
+      antV2.balance &&
+      new TokenAmount(antV2.balance, antV2.decimals).format({
+        digits: FORMATTED_DIGITS,
+      }),
+    [antV2.balance, antV2.decimals]
+  )
 
   return (
     <LayoutLimiter size="medium">
@@ -24,12 +46,12 @@ function Balances(): JSX.Element {
         <BalanceCard
           tokenVersion="v1"
           price={antTokenPriceUsd}
-          balance="78,924,954.82"
+          balance={formattedAntV1Balance}
         />
         <BalanceCard
           tokenVersion="v2"
           price={antTokenPriceUsd}
-          balance="78,924,954.82"
+          balance={formattedAntV2Balance}
         />
       </div>
     </LayoutLimiter>


### PR DESCRIPTION
Note here that I'm using the existence of the balance to determine whether to show the balances in the "connected" state, rather than checking for wallet connection directly. This avoids flickering of empty space as the balances are only requested after account connection, thus we only show them after they are available.

![image](https://user-images.githubusercontent.com/11708259/96252077-4e26fe00-0fa9-11eb-9907-557a81700623.png)
