### PR TITLE
Global: Use alternative scroll reset

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,18 +29,8 @@
     <title>Aragon Migrate</title>
 
     <style>
-      /* Override Aragon UI and restore scroll control to window element */
-      html, body {
-        min-height: auto !important;
-        height: auto !important;
-      }
-
-      html {
-        overflow-y: scroll !important;
-      }
-      
       body {
-        overflow: auto !important;
+        overflow-y: scroll !important;
 
         /* Match app background color to avoid white flicker on first load */
         background-color: #F9FAFC; 

--- a/src/components/MainView.tsx
+++ b/src/components/MainView.tsx
@@ -10,9 +10,9 @@ type Props = {
 const MainView = React.memo(function MainView({ children }: Props) {
   const { pathname } = useLocation()
 
-  // Reset scroll position to top on navigate
+  // Reset scroll position on route change
   useEffect(() => {
-    window.scrollTo(0, 0)
+    document.getElementsByTagName('body')[0].scrollTo(0, 0)
   }, [pathname])
 
   return (


### PR DESCRIPTION
My previous change to use window scrolling caused issues with modal overflow scrolls. This solution is simpler and doesn't cause those problems.