### PR TITLE
Add activity provider

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
     // Loosen checks to ease integration with existing untyped packages
     '@typescript-eslint/ban-ts-comment': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-non-null-assertion': 'off',
   },
   ignorePatterns: ['src/abi/types/index.ts'],
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { breakpoints } from './style/breakpoints'
 import { WalletProvider } from './providers/Wallet'
 import { AccountBalancesProvider } from './providers/AccountBalances'
 import { AccountModuleProvider } from './components/Account/AccountModuleProvider'
+import { ActivityProvider } from './providers/ActivityProvider'
 
 function App(): JSX.Element {
   return (
@@ -17,13 +18,15 @@ function App(): JSX.Element {
       <UseTokenProvider>
         <AccountBalancesProvider>
           <AccountModuleProvider>
-            <LayoutProvider breakpoints={breakpoints}>
-              <Router>
-                <MainView>
-                  <Routes />
-                </MainView>
-              </Router>
-            </LayoutProvider>
+            <ActivityProvider>
+              <LayoutProvider breakpoints={breakpoints}>
+                <Router>
+                  <MainView>
+                    <Routes />
+                  </MainView>
+                </Router>
+              </LayoutProvider>
+            </ActivityProvider>
           </AccountModuleProvider>
         </AccountBalancesProvider>
       </UseTokenProvider>

--- a/src/StoredList/StoredList.test.ts
+++ b/src/StoredList/StoredList.test.ts
@@ -8,26 +8,38 @@ const MOCK_ITEM2 = {
   description: 'mock description 2',
 }
 
-describe('StoredList.', () => {
-  const list = new StoredList<{ description: string }>('key')
-  const spyLocalStorage = jest.spyOn(Storage.prototype, 'setItem')
+function createStoredList(key: string) {
+  return new StoredList<{ description: string }>(key)
+}
 
-  it('update() updates the list and stores in localStorage', () => {
-    list.update([MOCK_ITEM])
-    expect(list.getItems()).toEqual([MOCK_ITEM])
+describe('StoredList.', () => {
+  it('update() replaces the list and stores in localStorage', () => {
+    const list = createStoredList('update-test')
+    const spyLocalStorage = jest.spyOn(Storage.prototype, 'setItem')
+
+    list.update([MOCK_ITEM2])
+    list.update([MOCK_ITEM, MOCK_ITEM2])
+
+    expect(list.getItems()).toEqual([MOCK_ITEM, MOCK_ITEM2])
     expect(spyLocalStorage).toBeCalledWith(
-      'key',
-      '[{"description":"mock description 1"}]'
+      'update-test',
+      '[{"description":"mock description 1"},{"description":"mock description 2"}]'
     )
   })
 
   it('add() correctly adds an item to the list', () => {
+    const list = createStoredList('add-test')
+
+    list.add(MOCK_ITEM)
     list.add(MOCK_ITEM2)
 
     expect(list.getItems()).toEqual([MOCK_ITEM, MOCK_ITEM2])
   })
 
   it('remove() removes an item from the list via index', () => {
+    const list = createStoredList('remove-test')
+
+    list.update([MOCK_ITEM, MOCK_ITEM2])
     list.remove(1)
     expect(list.getItems()).toEqual([MOCK_ITEM])
   })

--- a/src/StoredList/StoredList.test.ts
+++ b/src/StoredList/StoredList.test.ts
@@ -1,0 +1,34 @@
+import StoredList from './StoredList'
+
+const MOCK_ITEM = {
+  description: 'mock description 1',
+}
+
+const MOCK_ITEM2 = {
+  description: 'mock description 2',
+}
+
+describe('StoredList.', () => {
+  const list = new StoredList<{ description: string }>('key')
+  const spyLocalStorage = jest.spyOn(Storage.prototype, 'setItem')
+
+  it('update() updates the list and stores in localStorage', () => {
+    list.update([MOCK_ITEM])
+    expect(list.getItems()).toEqual([MOCK_ITEM])
+    expect(spyLocalStorage).toBeCalledWith(
+      'key',
+      '[{"description":"mock description 1"}]'
+    )
+  })
+
+  it('add() correctly adds an item to the list', () => {
+    list.add(MOCK_ITEM2)
+
+    expect(list.getItems()).toEqual([MOCK_ITEM, MOCK_ITEM2])
+  })
+
+  it('remove() removes an item from the list via index', () => {
+    list.remove(1)
+    expect(list.getItems()).toEqual([MOCK_ITEM])
+  })
+})

--- a/src/StoredList/StoredList.ts
+++ b/src/StoredList/StoredList.ts
@@ -1,0 +1,67 @@
+class StoredList<T> {
+  name
+  items
+
+  // name: the key used by StoredList to save the list in localStorage.
+  // preStringify: use this to transform an item of the list before being saved.
+  // postParse: use this to transform an item of the list after it got loaded.
+  constructor(name: string) {
+    this.name = name
+    this.items = this.loadItems()
+  }
+
+  private loadItems(): T[] {
+    let items = null
+    const value = localStorage.getItem(this.name)
+
+    if (value === null) {
+      return []
+    }
+
+    try {
+      items = JSON.parse(value)
+    } catch (err) {
+      console.error(
+        `StoredList (${this.name}) couldn’t parse the loaded items`,
+        err
+      )
+    }
+
+    if (!Array.isArray(items)) {
+      items = null
+      console.error(
+        `The data loaded by StoredList (${this.name}) is not an array`,
+        items
+      )
+    }
+
+    return items === null ? [] : items
+  }
+
+  private saveItems(): void {
+    localStorage.setItem(this.name, JSON.stringify(this.items))
+  }
+
+  getItems(): T[] {
+    return this.items
+  }
+
+  update(items: T[] = []): T[] {
+    this.items = items
+    this.saveItems()
+    return items
+  }
+
+  add(value: T): T[] {
+    return this.update([...this.items, value])
+  }
+
+  remove(index: number): T[] {
+    return this.update([
+      ...this.items.slice(0, index),
+      ...this.items.slice(index + 1),
+    ])
+  }
+}
+
+export default StoredList

--- a/src/StoredList/StoredList.ts
+++ b/src/StoredList/StoredList.ts
@@ -3,8 +3,6 @@ class StoredList<T> {
   items
 
   // name: the key used by StoredList to save the list in localStorage.
-  // preStringify: use this to transform an item of the list before being saved.
-  // postParse: use this to transform an item of the list after it got loaded.
   constructor(name: string) {
     this.name = name
     this.items = this.loadItems()

--- a/src/components/Account/AccountButton.tsx
+++ b/src/components/Account/AccountButton.tsx
@@ -18,7 +18,6 @@ type AccountButtonProps = {
 function AccountButton({ onClick }: AccountButtonProps): JSX.Element {
   const theme = useTheme()
   const { account } = useWallet()
-
   const { layoutName } = useLayout()
   const compactMode = layoutName === 'small'
 

--- a/src/providers/ActivityProvider.tsx
+++ b/src/providers/ActivityProvider.tsx
@@ -224,6 +224,7 @@ function useActivity(): {
     return activities.reduce((count, { read }) => count + Number(!read), 0)
   }, [activities])
 
+  // Determine whether there are any pending activities in the list
   const hasPending = useMemo(() => {
     return activities.some(({ status }) => status === 'pending')
   }, [activities])

--- a/src/providers/ActivityProvider.tsx
+++ b/src/providers/ActivityProvider.tsx
@@ -1,0 +1,283 @@
+import React, {
+  MutableRefObject,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import PropTypes from 'prop-types'
+import StoredList from '../StoredList/StoredList'
+import { MINUTE } from '../utils/date-utils'
+import { useWallet, Web3Provider } from '../providers/Wallet'
+import { networkEnvironment } from '../environment'
+import { ContractTransaction } from 'ethers'
+
+const TIMEOUT_DURATION = 10 * MINUTE
+
+const networkType = networkEnvironment.legacyNetworkType
+
+type Status = 'confirmed' | 'failed' | 'pending' | 'timeout'
+
+type ActionType = 'convertANT'
+
+type Activity = {
+  createdAt: number
+  description: string
+  from: string
+  nonce: number
+  read: boolean
+  status: Status
+  type: ActionType
+  to?: string
+  transactionHash: string
+}
+
+type Activities = Activity[]
+
+type ActivityContextState = {
+  activities: Activities
+  updateActivities: (cb: (activities: Activities) => Activities) => void
+}
+
+const ActivityContext = React.createContext<ActivityContextState | null>(null)
+
+function getStoredList(account: string) {
+  return new StoredList<Activity>(`activity:${networkType}:${account}`)
+}
+
+async function getActivityFinalStatus(
+  ethers: Web3Provider,
+  activityDetails: {
+    createdAt: number
+    transactionHash: string
+    status: Status
+  }
+): Promise<Status> {
+  const { createdAt, transactionHash, status } = activityDetails
+
+  if (status !== 'pending') {
+    return status
+  }
+
+  const now = Date.now()
+
+  // Get the transaction status once mined
+  const getTransactionStatus: Promise<'confirmed' | 'failed'> = ethers
+    .getTransaction(String(transactionHash))
+    .then((tx) => {
+      // tx is null if no tx was found
+      if (!tx) {
+        throw new Error('No transaction found')
+      }
+      return tx.wait().then((receipt) => {
+        return receipt.blockNumber ? 'confirmed' : 'failed'
+      })
+    })
+    .catch(() => {
+      return 'failed'
+    })
+
+  // Timeout after 10 minutes
+  const timeout = new Promise<'timeout'>((resolve) => {
+    if (now - createdAt > TIMEOUT_DURATION) {
+      return 'timeout'
+    }
+    setTimeout(() => {
+      resolve('timeout')
+    }, TIMEOUT_DURATION - (now - createdAt))
+  })
+
+  return Promise.race([getTransactionStatus, timeout])
+}
+
+function ActivityProvider({ children }: { children: ReactNode }): JSX.Element {
+  const [activities, setActivities] = useState<Activities>([])
+  const storedList = useRef() as MutableRefObject<StoredList<Activity>>
+  const wallet = useWallet()
+  const { account, ethers } = wallet
+
+  // Update the activities, ensuring the activities
+  // are updated in the stored list and in the state.
+  const updateActivities = useCallback(
+    (cb: (activities: Activities) => Activities) => {
+      const newActivities = cb(activities)
+      setActivities(newActivities)
+      if (storedList.current) {
+        storedList.current.update(newActivities)
+      }
+    },
+    [activities, storedList]
+  )
+
+  // Update the status of a single activity,
+  // using its transaction hash.
+  const updateActivityStatus = useCallback(
+    (hash, status) => {
+      updateActivities((activities: Activities) =>
+        activities.map((activity) => {
+          if (activity.transactionHash !== hash) {
+            return activity
+          }
+          return { ...activity, read: false, status }
+        })
+      )
+    },
+    [updateActivities]
+  )
+
+  const updateActivitiesFromStorage = useCallback(() => {
+    if (!storedList.current) {
+      return
+    }
+
+    const activitiesFromStorage = storedList.current.getItems()
+
+    // We will diff activities from storage and activites from state to prevent loops in the useEffect below
+    const activitiesChanged =
+      activities.length !== activitiesFromStorage.length ||
+      activitiesFromStorage.filter(
+        ({ transactionHash }) =>
+          activities.findIndex(
+            (activity) => activity.transactionHash === transactionHash
+          ) === -1
+      ).length > 0
+
+    if (activitiesChanged) {
+      setActivities(activitiesFromStorage)
+    }
+  }, [activities, storedList])
+
+  // Triggered every time the account changes
+  useEffect(() => {
+    if (!account) {
+      return
+    }
+
+    let cancelled = false
+    storedList.current = getStoredList(account)
+    updateActivitiesFromStorage()
+
+    if (ethers) {
+      activities.forEach(async (activity) => {
+        const status = await getActivityFinalStatus(ethers, activity)
+        if (!cancelled && status !== activity.status) {
+          updateActivityStatus(activity.transactionHash, status)
+        }
+      })
+    }
+
+    return () => {
+      cancelled = true
+    }
+  }, [
+    account,
+    activities,
+    ethers,
+    updateActivitiesFromStorage,
+    updateActivityStatus,
+    storedList,
+  ])
+
+  const contextValue = {
+    activities,
+    updateActivities,
+  }
+
+  return (
+    <ActivityContext.Provider value={contextValue}>
+      {children}
+    </ActivityContext.Provider>
+  )
+}
+
+ActivityProvider.propTypes = {
+  children: PropTypes.node,
+}
+
+function useActivity(): {
+  activities: Activities
+  unreadCount: number
+  hasPending: boolean
+  markActivitiesRead: () => void
+  addActivity: (
+    tx: ContractTransaction,
+    type: ActionType,
+    description: string
+  ) => ContractTransaction
+  clearActivities: () => void
+  removeActivity: (hash: string) => void
+} {
+  const { updateActivities, activities } = useContext(ActivityContext)!
+
+  // Mark the current user’s activities as read
+  const markActivitiesRead = useCallback(() => {
+    updateActivities((activities: Activities) =>
+      activities.map((activity) => ({ ...activity, read: true }))
+    )
+  }, [updateActivities])
+
+  // Total number of unread activities
+  const unreadCount = useMemo(() => {
+    return activities.reduce((count, { read }) => count + Number(!read), 0)
+  }, [activities])
+
+  const hasPending = useMemo(() => {
+    return activities.some(({ status }) => status === 'pending')
+  }, [activities])
+
+  // Add a single activity.
+  const addActivity = useCallback(
+    (tx: ContractTransaction, type: ActionType, description = '') => {
+      updateActivities((activities: Activities) => [
+        ...activities,
+        {
+          createdAt: Date.now(),
+          description,
+          from: tx.from,
+          nonce: tx.nonce,
+          read: false,
+          status: 'pending',
+          type,
+          to: tx.to,
+          transactionHash: tx.hash,
+        },
+      ])
+
+      return tx
+    },
+    [updateActivities]
+  )
+
+  // Clear all non pending activities − we don’t clear
+  // pending because we’re awaiting state change.
+  const clearActivities = useCallback(() => {
+    updateActivities((activities: Activities) =>
+      activities.filter((activity) => activity.status === 'pending')
+    )
+  }, [updateActivities])
+
+  // Clear a single activity
+  const removeActivity = useCallback(
+    (hash: string) => {
+      updateActivities((activities: Activities) =>
+        activities.filter((activity) => activity.transactionHash !== hash)
+      )
+    },
+    [updateActivities]
+  )
+
+  return {
+    activities,
+    markActivitiesRead,
+    unreadCount,
+    addActivity,
+    clearActivities,
+    removeActivity,
+    hasPending,
+  }
+}
+
+export { ActivityProvider, useActivity }

--- a/src/providers/Wallet.tsx
+++ b/src/providers/Wallet.tsx
@@ -6,8 +6,10 @@ import { networkEnvironment } from '../environment'
 import { getUseWalletConnectors } from '../components/Account/ethereum-providers'
 import { WalletWithProvider } from '../components/Account/types'
 
+export type Web3Provider = EthersProviders.Web3Provider
+
 type WalletContext = {
-  ethers: EthersProviders.Web3Provider | null
+  ethers: Web3Provider | null
 } & WalletWithProvider
 
 const WalletAugmentedContext = React.createContext<WalletContext | null>(null)

--- a/src/utils/date-utils.ts
+++ b/src/utils/date-utils.ts
@@ -1,0 +1,4 @@
+export const SECOND = 1000
+export const MINUTE = 60 * SECOND
+export const HOUR = 60 * MINUTE
+export const DAY = 24 * HOUR


### PR DESCRIPTION
This PR adds an activity provider for use with the account module to display recent transactions as well as provide feedback to users when transactions are working / pending on the network. There are no user-facing UI changes yet as that will come in a separate improvement.