### PR TITLE
fetching option amounts from datafeed DAO-218

### DIFF
--- a/src/components/Check/CheckerControls.tsx
+++ b/src/components/Check/CheckerControls.tsx
@@ -133,7 +133,7 @@ function ConversionInfo() {
         target="_blank"
         rel="noopener noreferrer"
         href={
-          'https://help.aragon.org/article/108-redeeming-aragon-govern-reward-kpi-options'
+          'https://help.aragon.org/article/99-aragon-govern-migration-reward-program#redeeming'
         }
       >
         this article

--- a/src/components/Check/CheckerControls.tsx
+++ b/src/components/Check/CheckerControls.tsx
@@ -12,19 +12,26 @@ import BrandButton from '../BrandButton/BrandButton'
 import ConverterFormControls from '../Migrate/Converter/ConverterFormControls'
 import styled from 'styled-components'
 import { Case, Switch } from 'react-if'
-import { optionsInfo } from '../../token-info/options'
+import { DaoAddress, optionsInfo, TxHash } from '../../token-info/options'
 import { isAddress } from 'ethers/lib/utils'
 import { constants } from 'ethers/lib/index'
 
-type ComponentState = 'init' | 'error' | 'options' | 'no options' | 'with tx'
+type ComponentState =
+  | 'init'
+  | 'invalid address'
+  | 'error'
+  | 'options'
+  | 'no options'
+  | 'with tx'
 
 export function BaseCheckerFormControls(): JSX.Element {
   const history = useHistory()
   const { layoutName } = useLayout()
-  const [address, setAddress] = useState('')
-  const [state, setState] = useState<ComponentState>('init')
+
+  const [address, setAddress] = useState<DaoAddress>('')
+  const [tx, setTx] = useState<TxHash>('')
   const [options, setOptions] = useState(0)
-  const [tx, setTx] = useState('')
+  const [state, setState] = useState<ComponentState>('init')
 
   const handleNavigateHome = useCallback(() => {
     history.push('/')
@@ -37,15 +44,24 @@ export function BaseCheckerFormControls(): JSX.Element {
     setAddress(value)
   }, [])
 
-  const handleSubmit = () => {
-    if (!isAddress(address)) return setState('error')
-
-    const optionsAmount = optionsInfo[address]
-    if (!optionsAmount) return setState('no options')
-    setOptions(optionsAmount.amount)
-    if (!optionsAmount.txHash) return setState('options')
-    setTx(optionsAmount.txHash)
-    return setState('with tx')
+  const handleSubmit = async () => {
+    if (!isAddress(address)) return setState('invalid address')
+    try {
+      const response = await fetch(
+        `https://datafeed.aragon.org/organizations/${address}`
+      )
+      if (response.status === 404) return setState('no options')
+      if (response.ok) {
+        const data = await response.json()
+        setOptions(data.value)
+      }
+      const tx: TxHash = optionsInfo[address]
+      if (!tx) return setState('options')
+      setTx(tx)
+      return setState('with tx')
+    } catch (err) {
+      return setState('error')
+    }
   }
 
   return (
@@ -73,26 +89,31 @@ export function BaseCheckerFormControls(): JSX.Element {
       </ButtonRow>
       <InfoColumn>
         <Switch>
+          <Case condition={state === 'invalid address'}>
+            <Info mode={'error'}>This address is invalid.</Info>
+          </Case>
           <Case condition={state === 'error'}>
-            <Info mode={'error'}>This address is invalid</Info>
+            <Info mode={'error'}>
+              Something went wrong while fetching data. Please try again later.
+            </Info>
           </Case>
           <Case condition={state === 'no options'}>
-            <Info>Your DAO is not entitled to receive options</Info>
+            <Info>Your DAO is not entitled to receive any options.</Info>
             <ConversionInfo />
           </Case>
           <Case condition={state === 'options'}>
-            <Info>Your DAO is entitled to {options} options</Info>
+            <Info>Your DAO is entitled to {options} options.</Info>
             <ConversionInfo />
           </Case>
           <Case condition={state === 'with tx'}>
             <Info>
-              Your DAO has received {options}. Check the transaction{' '}
+              Your DAO has received {options} options. Check the transaction{' '}
               <a
                 target="_blank"
                 rel="noopener noreferrer"
                 href={`https://etherscan.io/tx/${tx}`}
               >
-                here
+                here.
               </a>
             </Info>
             <ConversionInfo />

--- a/src/components/Check/OptionRate.tsx
+++ b/src/components/Check/OptionRate.tsx
@@ -68,6 +68,7 @@ function OptionRate({ tokenSymbol }: OptionRateProps): JSX.Element {
             css={`
               font-weight: ${fontWeight.medium};
               font-size: 18px;
+              margin-right: 8px;
             `}
           >
             Current conversion rate
@@ -79,7 +80,7 @@ function OptionRate({ tokenSymbol }: OptionRateProps): JSX.Element {
               <a
                 target="_blank"
                 rel="noopener noreferrer"
-                href="https://help.aragon.org/article/99-aragon-govern-migration-reward-program#redeeming"
+                href="https://blog.aragon.org/uma-kpi-options-airdrop-now-live-for-aragon-govern-daos/"
               >
                 here
               </a>

--- a/src/components/Check/OptionRate.tsx
+++ b/src/components/Check/OptionRate.tsx
@@ -68,7 +68,7 @@ function OptionRate({ tokenSymbol }: OptionRateProps): JSX.Element {
             css={`
               font-weight: ${fontWeight.medium};
               font-size: 18px;
-              margin-right: 8px;
+              margin-right: ${1 * GU};
             `}
           >
             Current conversion rate

--- a/src/token-info/options.ts
+++ b/src/token-info/options.ts
@@ -1,18 +1,8 @@
-type TokenAddress = string
-type TransactionHash = string
-type OptionInfo = {
-  amount: number
-  txHash?: TransactionHash
-}
+export type DaoAddress = string
+export type TxHash = string
 
-// TODO Add information for migration options here
-export const optionsInfo: Record<TokenAddress, OptionInfo> = {
-  '0x8367dc645e31321CeF3EeD91a10a5b7077e21f70': {
-    amount: 42,
-  },
-  '0x000000000000000000000000000000000000dEaD': {
-    amount: -1,
-    txHash:
-      '0x7b6f030dbbf8ee4e22488b4edf239f0e9cdbaa54fcef985c81d324bd3cbccffb',
-  },
+// Add tx hashes (values) for DAOs (keys) that received their options.
+export const optionsInfo: Record<DaoAddress, TxHash> = {
+  '0x8367dc645e31321CeF3EeD91a10a5b7077e21f70':
+    '0x7b6f030dbbf8ee4e22488b4edf239f0e9cdbaa54fcef985c81d324bd3cbccffb',
 }

--- a/src/token-info/options.ts
+++ b/src/token-info/options.ts
@@ -3,6 +3,7 @@ export type TxHash = string
 
 // Add tx hashes (values) for DAOs (keys) that received their options.
 export const optionsInfo: Record<DaoAddress, TxHash> = {
-  '0x8367dc645e31321CeF3EeD91a10a5b7077e21f70':
-    '0x7b6f030dbbf8ee4e22488b4edf239f0e9cdbaa54fcef985c81d324bd3cbccffb',
+  // this is an example entry:
+  // '0x8367dc645e31321CeF3EeD91a10a5b7077e21f70':
+  //   '0x7b6f030dbbf8ee4e22488b4edf239f0e9cdbaa54fcef985c81d324bd3cbccffb',
 }


### PR DESCRIPTION
This PR fixes how the amount of option a DAO is entitled to get is obtained. Instead of reading from a file, the information is now fetched from datafeed.aragon.org/organizations/<orgAddress>.